### PR TITLE
Add seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
   gem "faker", "~> 2.14"
   gem "letter_opener_web", "~> 2.0"
   gem "listen", "~> 3.1"
+  gem "rack-mini-profiler", require: false
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"
   gem "web-console", "~> 4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,6 +556,8 @@ GEM
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-mini-profiler (3.1.0)
+      rack (>= 1.2.0)
     rack-protection (3.0.6)
       rack
     rack-proxy (0.7.6)
@@ -780,6 +782,7 @@ DEPENDENCIES
   letter_opener_web (~> 2.0)
   listen (~> 3.1)
   puma (>= 4.3)
+  rack-mini-profiler
   rubocop-faker (~> 1.1)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)

--- a/Rakefile
+++ b/Rakefile
@@ -23,12 +23,6 @@ task :development_app do
   seed_slider("development_app")
 end
 
-def seed_db(path)
-  Dir.chdir(path) do
-    system("bundle exec rake db:seed")
-  end
-end
-
 def seed_slider(path)
   Dir.chdir(path) do
     system("bundle exec rake decidim:homepage_proposals:seed")

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,31 @@ desc "Generates a dummy app for testing"
 task test_app: "decidim:generate_external_test_app"
 
 desc "Generates a development app."
-task development_app: "decidim:generate_external_development_app"
+task :development_app do
+  Bundler.with_original_env do
+    generate_decidim_app(
+      "development_app",
+      "--app_name",
+      "#{base_app_name}_development_app",
+      "--path",
+      "..",
+      "--recreate_db",
+      "--seed_db",
+      "--demo",
+      "--profiling"
+    )
+  end
+  seed_slider("development_app")
+end
+
+def seed_db(path)
+  Dir.chdir(path) do
+    system("bundle exec rake db:seed")
+  end
+end
+
+def seed_slider(path)
+  Dir.chdir(path) do
+    system("bundle exec rake decidim:homepage_proposals:seed")
+  end
+end

--- a/lib/decidim/homepage_proposals/engine.rb
+++ b/lib/decidim/homepage_proposals/engine.rb
@@ -34,7 +34,6 @@ module Decidim
             settings.attribute :linked_components_id, type: :array
             settings.attribute :default_linked_component, type: :integer
           end
-          content_block.default!
         end
       end
     end

--- a/lib/tasks/homepage_proposals.rake
+++ b/lib/tasks/homepage_proposals.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :homepage_proposals do
+    desc "Seed module"
+    task seed: :environment do
+      organization = Decidim::Organization.first
+
+      components = Decidim::Component.where(manifest_name: "proposals").where.not(participatory_space: nil)
+
+      Decidim::ContentBlock.create(
+        decidim_organization_id: organization.id,
+        weight: 1,
+        scope_name: :homepage,
+        manifest_name: :proposals_slider,
+        published_at: Time.current,
+        settings: {
+          activate_filters: true,
+          linked_components_id: [components.first.id, components.second.id],
+          default_linked_component: components.first.id
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR makes the content block not activated by default.

It also generates a fully created slider when generating a dev app.

It can't be added to the seeds as module seeds are triggered before the creation of components.