### PR TITLE
Add tags on proposal cards

### DIFF
--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -23,7 +23,9 @@ module Decidim
           body: translated_attribute(proposal.body).truncate(150),
           url: proposal_path(proposal),
           image: image_for(proposal),
-          state: proposal.state
+          state: proposal.state,
+          category: proposal.category ? cell("decidim/tags", proposal).render(:category).strip.html_safe : '',
+          scope: proposal.scope ? cell("decidim/tags", proposal).render(:scope).strip.html_safe : ''
         }
       end
     end

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -9,6 +9,8 @@ export default class Proposal extends GlideItem {
         this.url = obj.url;
         this.state = obj.state || 'not answered' ;
         this.color = this.colorFromState(this.state);
+        this.scope = obj.scope;
+        this.category = obj.category;
     }
 
     colorFromState(state) {
@@ -24,6 +26,13 @@ export default class Proposal extends GlideItem {
         }
     }
 
+    getTagsTemplate() {
+        return `<ul class="tags tags--proposal">
+    ${this.category}
+    ${this.scope}
+</ul>`
+    }
+
     render() {
         return `<div class="column glide__slide">
 <div class="card card--proposal card--stack">
@@ -33,9 +42,11 @@ export default class Proposal extends GlideItem {
 </div>
     </a>
     <div class="card--process__small text-center padding-1">
-            <span class="${this.color} card__text--status status_slider"> ${this.state.charAt(0).toUpperCase() + this.state.slice(1)} </span>
+        <span class="${this.color} card__text--status status_slider"> ${this.state.charAt(0).toUpperCase() + this.state.slice(1)} </span>
         <a href="${this.url}"><h3 class="proposal-glance card__title">${this.title}</h3></a>
+        
         <div class="card__text--paragraph padding-top-1">
+            ${this.getTagsTemplate()}
             <p>${this.body}</p>
         </div>
         <a href="${this.url}">


### PR DESCRIPTION
This PR adds scope and category to proposal card 

![image](https://github.com/OpenSourcePolitics/decidim-module_homepage_proposals/assets/105683/52e1658e-e293-4ee6-acbf-dd15786d4360)

I went on rendering the tags directly from the JSON response, as i did not want to migrate whole link creation logic to the plugin. I also see that the proposal box has a "Visit" link that is not being translated. 