### PR TITLE
Set a fixed height for cards

### DIFF
--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -48,7 +48,7 @@ module Decidim
         end
 
         def categories_filter
-          @categories_filter ||= Decidim::Category.where(id: linked_components.map(&:categories).flatten)
+          @categories_filter ||= Decidim::Category.where(id: linked_components.map(&:categories).flatten).map { |category| [translated_attribute(category.name), category.id] }
         end
 
         def selected_component_id

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -20,7 +20,8 @@ module Decidim
       glanced_proposals.flat_map do |proposal|
         {
           id: proposal.id,
-          title: translated_attribute(proposal.title).truncate(40),
+
+          title: translated_attribute(proposal.title).truncate(30),
           body: decidim_sanitize_editor(translated_attribute(proposal.body), strip_tags: true).truncate(150),
           url: proposal_path(proposal),
           image: image_for(proposal),

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -22,7 +22,7 @@ module Decidim
           id: proposal.id,
 
           title: translated_attribute(proposal.title).truncate(30),
-          body: decidim_sanitize_editor(translated_attribute(proposal.body), strip_tags: true).truncate(150),
+          body: decidim_sanitize(translated_attribute(proposal.body), strip_tags: true).truncate(150),
           url: proposal_path(proposal),
           image: image_for(proposal),
           state: proposal.state,

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -49,10 +49,10 @@ export default class Proposal extends GlideItem {
             ${this.getTagsTemplate()}
             ${this.body}
         </div>
+    </div>
+    <div class="card__button align-bottom padding-top-1">
         <a href="${this.url}">
-            <div class="card__button align-bottom padding-top-1">
-                <span class="button small button--secondary">Visit</span>
-            </div>
+            <span class="button small button--secondary">Visit</span>
         </a>
     </div>
   </div>

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -38,8 +38,8 @@ export default class Proposal extends GlideItem {
 <div class="card card--proposal card--stack">
     <a href="${this.url}">
       <div class="proposal-glance card--header">
-      <img src="${this.image}" class="proposal-glance__img" alt="slider_img">
-</div>
+        <img src="${this.image}" class="proposal-glance__img" alt="slider_img">
+      </div>
     </a>
     <div class="card--process__small text-center padding-1">
         <span class="${this.color} card__text--status status_slider"> ${this.state.charAt(0).toUpperCase() + this.state.slice(1)} </span>
@@ -50,7 +50,7 @@ export default class Proposal extends GlideItem {
             ${this.body}
         </div>
     </div>
-    <div class="card__button align-bottom padding-top-1">
+    <div class="card__button align-bottom text-center padding-top-1">
         <a href="${this.url}">
             <span class="button small button--secondary">Visit</span>
         </a>

--- a/app/packs/stylesheets/decidim/homepage_proposals/homepage_proposals.scss
+++ b/app/packs/stylesheets/decidim/homepage_proposals/homepage_proposals.scss
@@ -53,7 +53,7 @@
 
 .glide__slide {
   .card--process__small {
-    height: 340px;
+    height: 250px;
     
     .card__text--paragraph {
       height: 200px;

--- a/app/packs/stylesheets/decidim/homepage_proposals/homepage_proposals.scss
+++ b/app/packs/stylesheets/decidim/homepage_proposals/homepage_proposals.scss
@@ -1,9 +1,5 @@
 @import "@glidejs/glide/src/assets/sass/glide.core";
 
-.card__text--paragraph {
-  height: 150px;
-}
-
 // glide's relative position prevents filters from being clicked
 .glide {
   position: inherit !important;
@@ -53,4 +49,14 @@
 .flex-justify-end {
   display: flex;
   justify-content: end
+}
+
+.glide__slide {
+  .card--process__small {
+    height: 340px;
+    
+    .card__text--paragraph {
+      height: 200px;
+    }
+  }
 }

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -14,11 +14,12 @@
       </div>
       <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.about") %></p>
       <div>
-        <%= form.categories_select :category_id,
+        <%= form.collection_select :category_id,
                                    categories_filter,
-                                   disable_parents: false,
+                                   :last,
+                                   :first,
+                                   root: false,
                                    label: false,
-                                   selected: filter.category_id,
                                    include_blank: t("decidim.homepage_proposals.proposal_at_a_glance.filters.default_categories") %>
       </div>
       <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.in") %></p>


### PR DESCRIPTION
There is no right answer for this at this point. To have a more concludent way for thin, we should encapsulate each one of the elements ( title, tags, body, link) in its own container with a fixed height. 

![image](https://github.com/OpenSourcePolitics/decidim-module_homepage_proposals/assets/105683/477ea642-59f1-404c-8b02-744ecf10374a)

In this PR i have set the box height to 340px, and i have truncated the text to 30 chars to avoid second line of the element.
