### PR TITLE
Sanitize Proposal body

### DIFF
--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     include Decidim::TranslatableAttributes
     include Decidim::Core::Engine.routes.url_helpers
     include Decidim::ComponentPathHelper
+    include Decidim::SanitizeHelper
 
     def refresh_proposals
       render json: build_proposals_api
@@ -20,7 +21,7 @@ module Decidim
         {
           id: proposal.id,
           title: translated_attribute(proposal.title).truncate(40),
-          body: translated_attribute(proposal.body).truncate(150),
+          body: decidim_sanitize_editor(translated_attribute(proposal.body), strip_tags: true).truncate(150),
           url: proposal_path(proposal),
           image: image_for(proposal),
           state: proposal.state,

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -47,7 +47,7 @@ export default class Proposal extends GlideItem {
         
         <div class="card__text--paragraph padding-top-1">
             ${this.getTagsTemplate()}
-            <p>${this.body}</p>
+            ${this.body}
         </div>
         <a href="${this.url}">
             <div class="card__button align-bottom padding-top-1">


### PR DESCRIPTION
Use decidim sanitization techniques to strip any image or formatting that may break the box. 

![image](https://github.com/OpenSourcePolitics/decidim-module_homepage_proposals/assets/105683/d2aa940e-84e3-4a12-8328-363eb75ca3cf)
